### PR TITLE
Version 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is a Minecraft plugin for Spigot/Paper servers that allows players to set t
 - The status of every player is saved to a file, so they will keep their status when they rejoin the server.
 - The Plugin supports `PlaceholderAPI v2.11.5`
   - The Plugin reloads statuses every 600 Game Ticks (30seconds) so the Placeholders can update themselves.
+  - The Plugin now got a Placeholder`%tubsstatusplugin_status_playername%` (playname should be changed out for the real Playername, Duuuh.)
 
 ## Permissions
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a Minecraft plugin for Spigot/Paper servers that allows players to set t
 
 - Set your own status with `/status <status>`
 - Remove your status with `/status remove`
-- Set status with formatting codes (for example to color them) with `/status &3<status>`
+- Set status with formatting codes (for example to color them) with `/status &3<status> (/status help colorcodes)`
 - Set other players' statuses with `/status <player> <status>` (requires `StatusPlugin.admin.setStatus` permission)
 - Remove other players' statuses with `/status remove <player>` (requires `StatusPlugin.admin.setStatus` permission)
 - Reload all statuses from file with `/status reload` (requires `StatusPlugin.admin.reload` permission) (Can be executed by console)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.tubyoub</groupId>
     <artifactId>StatusPlugin</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <packaging>jar</packaging>
 
     <name>Tub's Status Plugin</name>
@@ -40,11 +40,11 @@
                             </excludes>
                         </filter>
                     </filters>
-                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                     <outputFile>D:\papermc\plugins\TubsStatusPlugin-v${project.version}.jar</outputFile>
                     <outputFile>target\TubsStatusPlugin-v${project.version}.jar</outputFile>
                 </configuration>
-                <executions>
+                <executions> 
                     <execution>
                         <phase>package</phase>
                         <goals>
@@ -57,10 +57,6 @@
         <resources>
             <resource>
                 <directory>${project.basedir}/src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-            <resource>
-                <directory>${project.basedir}/src/main/java</directory>
                 <filtering>true</filtering>
             </resource>
         </resources>
@@ -98,6 +94,11 @@
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.dejvokep</groupId>
+            <artifactId>boosted-yaml</artifactId>
+            <version>1.3.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/de/tubyoub/statusplugin/Listener/ChatListener.java
+++ b/src/main/java/de/tubyoub/statusplugin/Listener/ChatListener.java
@@ -1,7 +1,9 @@
 package de.tubyoub.statusplugin.Listener;
 
+import de.tubyoub.statusplugin.Managers.ConfigManager;
 import de.tubyoub.statusplugin.Managers.StatusManager;
 import de.tubyoub.utils.ColourUtils;
+import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -9,26 +11,53 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerChatEvent;
 
+/**
+ * Class implementing the Listener interface to handle player chat events.
+ * When a player sends a chat message, the message is formatted based on the player's status.
+ */
 public class ChatListener implements Listener {
     private final StatusManager statusManager;
-    public ChatListener(StatusManager statusManager) {
+    private final ConfigManager configManager;
+
+    /**
+     * Constructor for the ChatListener class.
+     * @param statusManager The StatusManager instance used to manage player statuses.
+     * @param configManager The ConfigManager instance used to manage the plugin configuration.
+     */
+    public ChatListener(StatusManager statusManager, ConfigManager configManager) {
         this.statusManager = statusManager;
+        this.configManager = configManager;
     }
+
+    /**
+     * Event handler for player chat events.
+     * When a player sends a chat message, the message is formatted based on the player's status.
+     * If the player has a status, it is added to the beginning of the message.
+     * If the player does not have a status, the message is sent as is.
+     * @param event The PlayerChatEvent to be handled.
+     */
     @EventHandler
     public void onPlayerChat(PlayerChatEvent event) {
-        // Get the player and message
-        Player player = event.getPlayer();
-        String message = event.getMessage();
-        String status = statusManager.getStatus(player);
-        String broadcastMessage;
+        if (configManager.isChatFormatter()) {
+            // Get the player and message
+            Player player = event.getPlayer();
+            String message = event.getMessage();
 
-        if (status == null) {
-            broadcastMessage = player.getName() + ": " + message;
-        } else {
-            broadcastMessage = "[" + ColourUtils.format(status) + ChatColor.RESET + "] " + player.getName() + ": " + message;
+            // Translate the player's status and add placeholders
+            String status = statusManager.translateColorsAndFormatting(statusManager.getStatus(player),player);
+            status = PlaceholderAPI.setPlaceholders(player, status);
+
+            // Format the broadcast message
+            String broadcastMessage;
+            if (status == null) {
+                broadcastMessage = player.getName() + ": " + message;
+            } else {
+                broadcastMessage = "[" + ColourUtils.format(status) + ChatColor.RESET + "] " + player.getName() + ": " + message;
+            }
+
+            // Broadcast the message and cancel the original event
+            Bukkit.broadcastMessage(broadcastMessage);
+            event.setCancelled(true);
         }
-        Bukkit.broadcastMessage(broadcastMessage);
-        // Cancel the original event
-        event.setCancelled(true);
     }
 }

--- a/src/main/java/de/tubyoub/statusplugin/Listener/PlayerJoinListener.java
+++ b/src/main/java/de/tubyoub/statusplugin/Listener/PlayerJoinListener.java
@@ -6,17 +6,29 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
+/**
+ * Class implementing the Listener interface to handle player join events.
+ * When a player joins, their display name is updated based on their status.
+ */
 public class PlayerJoinListener implements Listener {
     private final StatusManager statusManager;
 
+    /**
+     * Constructor for the PlayerJoinListener class.
+     * @param statusManager The StatusManager instance used to manage player statuses.
+     */
     public PlayerJoinListener(StatusManager statusManager) {
         this.statusManager = statusManager;
     }
 
-@EventHandler
-public void onPlayerJoin(PlayerJoinEvent event) {
-    Player player = event.getPlayer();
-    statusManager.updateDisplayName(player);
-}
-
+    /**
+     * Event handler for player join events.
+     * When a player joins, their display name is updated based on their status.
+     * @param event The PlayerJoinEvent to be handled.
+     */
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        statusManager.updateDisplayName(player);
+    }
 }

--- a/src/main/java/de/tubyoub/statusplugin/Managers/ConfigManager.java
+++ b/src/main/java/de/tubyoub/statusplugin/Managers/ConfigManager.java
@@ -1,0 +1,82 @@
+package de.tubyoub.statusplugin.Managers;
+
+import de.tubyoub.statusplugin.StatusPlugin;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.dvs.versioning.BasicVersioning;
+import dev.dejvokep.boostedyaml.settings.dumper.DumperSettings;
+import dev.dejvokep.boostedyaml.settings.general.GeneralSettings;
+import dev.dejvokep.boostedyaml.settings.loader.LoaderSettings;
+import dev.dejvokep.boostedyaml.settings.updater.UpdaterSettings;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+
+public class ConfigManager {
+    private YamlDocument config;
+    private int maxStatusLength;
+    private boolean chatFormatter;
+    private boolean changeTabListNames;
+    private final StatusPlugin plugin;
+
+    public ConfigManager(StatusPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void loadConfig() {
+        try {
+            config = YamlDocument.create(new File(plugin.getDataFolder(), "config.yml"),
+                    Objects.requireNonNull(getClass().getResourceAsStream("/config.yml")),
+                    GeneralSettings.DEFAULT,
+                    LoaderSettings.builder().setAutoUpdate(true).build(),
+                    DumperSettings.DEFAULT,
+
+                    UpdaterSettings.builder().setVersioning(new BasicVersioning("fileversion"))
+                            .setOptionSorting(UpdaterSettings.OptionSorting.SORT_BY_DEFAULTS).build());
+
+            maxStatusLength = config.getInt("maxStatusLength", 15);
+            chatFormatter = config.getBoolean("chatFormatter", true);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Could not load configuration: " + e.getMessage());
+        }
+    }
+
+    public void saveConfig() {
+        try {
+            config.save();
+        } catch (IOException e) {
+            plugin.getLogger().severe("Could not save configuration: " + e.getMessage());
+        }
+    }
+
+    public boolean isChatFormatter(){
+        return chatFormatter;
+    }
+    public void setChatFormatter(boolean chatFormatter){
+        if (this.chatFormatter == chatFormatter){
+            return;
+        }else {
+            this.chatFormatter = chatFormatter;
+            config.set("chatFormatter", chatFormatter);
+        }
+    }
+    public int getMaxStatusLength() {
+        return maxStatusLength;
+    }
+
+    public void setMaxStatusLength(int maxLength) {
+        this.maxStatusLength = maxLength;
+        config.set("maxStatusLength", maxLength);
+        saveConfig();
+    }
+
+    public void resetMaxStatusLength() {
+        this.maxStatusLength = 15;
+        config.set("maxStatusLength", 15);
+        saveConfig();
+    }
+
+    public void reloadConfig() {
+        loadConfig();
+    }
+}

--- a/src/main/java/de/tubyoub/statusplugin/Managers/StatusManager.java
+++ b/src/main/java/de/tubyoub/statusplugin/Managers/StatusManager.java
@@ -1,6 +1,7 @@
 package de.tubyoub.statusplugin.Managers;
 
 import de.tubyoub.statusplugin.StatusPlugin;
+import de.tubyoub.utils.ColourUtils;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -13,13 +14,14 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.regex.Pattern;
 import java.util.regex.Matcher;
-import de.tubyoub.utils.ColourUtils;
+import java.util.regex.Pattern;
 
-import static org.bukkit.Bukkit.getConsoleSender;
 import static org.bukkit.Bukkit.getLogger;
 
+/**
+ * Class responsible for managing player statuses.
+ */
 public class StatusManager {
     private final File statusFile;
     private final Map<UUID, String> statusMap = new HashMap<>();
@@ -29,16 +31,32 @@ public class StatusManager {
     private final StatusPlugin plugin;
     private ColourUtils chatColour;
     private final boolean placeholderAPIPresent;
+    private ConfigManager configManager;
 
+    /**
+     * Constructor for the StatusManager class.
+     * @param plugin The StatusPlugin instance.
+     */
     public StatusManager(StatusPlugin plugin) {
         this.plugin = plugin;
         this.placeholderAPIPresent = Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null;
-        this.maxStatusLength = plugin.getConfig().getInt("maxStatusLength", DEFAULT_MAX_LENGTH);
+        this.configManager = plugin.getConfigManager();
+        maxStatusLength = configManager.getMaxStatusLength();
         this.statusFile = new File(plugin.getDataFolder(), "statuses.yml");
         loadStatuses();
     }
 
+    /**
+     * Method to set the status of a player.
+     * @param player The player whose status is to be set.
+     * @param status The status to be set.
+     * @param sender The sender of the command.
+     * @return A boolean indicating whether the status was set successfully.
+     */
     public boolean setStatus(Player player, String status, CommandSender sender) {
+        if (status.contains("&_")){
+            status = status.replace("&_", " ");
+        }
         String translatedStatus = translateColorsAndFormatting(status, sender);
         if (calculateEffectiveLength(translatedStatus) > maxStatusLength) {
             sender.sendMessage(ChatColor.RED + "Status is too long. Max length is " + maxStatusLength + " characters.");
@@ -52,20 +70,32 @@ public class StatusManager {
         return true;
     }
 
+    /**
+     * Method to get the status of a player.
+     * @param player The player whose status is to be retrieved.
+     * @return The status of the player.
+     */
     public String getStatus(Player player) {
         return statusMap.get(player.getUniqueId());
     }
 
+
+   /**
+     * Updates the display name of the player based on their status.
+     * If the player has a status, it is translated and added to their display name.
+     * If the player does not have a status, their display name is set to their name.
+     * @param player The player whose display name is to be updated.
+     */
     public void updateDisplayName(Player player) {
         String status = getStatus(player);
+
         if (status != null) {
-            // Translate the status here
             String translatedStatus = translateColorsAndFormatting(status, player);
             if (placeholderAPIPresent && player.hasPermission("StatusPlugin.placeholders")) {
                 translatedStatus = PlaceholderAPI.setPlaceholders(player, translatedStatus);
             }
             String displayName = "[" + translatedStatus + ChatColor.RESET + "] " + ChatColor.WHITE + player.getName();
-            displayName = ColourUtils.format(displayName); // Assign the result back to displayName
+            displayName = ColourUtils.format(displayName);
             player.setDisplayName(displayName);
             player.setPlayerListName(displayName);
         } else {
@@ -73,22 +103,37 @@ public class StatusManager {
             player.setPlayerListName(player.getName());
         }
     }
+
+    /**
+     * Returns the maximum length of a status.
+     * @return The maximum length of a status.
+     */
     public int getMaxStatusLength() {
         return maxStatusLength;
     }
 
+    /**
+     * Sets the maximum length of a status.
+     * @param maxLength The maximum length to be set.
+     */
     public void setMaxStatusLength(int maxLength) {
         this.maxStatusLength = maxLength;
-        plugin.getConfig().set("maxStatusLength", maxLength);
-        plugin.saveConfig();
+        configManager.setMaxStatusLength(maxLength);
+        configManager.saveConfig();
     }
 
+    /**
+     * Resets the maximum length of a status to the default value.
+     */
     public void resetMaxStatusLength() {
         this.maxStatusLength = DEFAULT_MAX_LENGTH;
-        plugin.getConfig().set("maxStatusLength", DEFAULT_MAX_LENGTH);
-        plugin.saveConfig();
+        configManager.resetMaxStatusLength();
+        configManager.saveConfig();
     }
 
+    /**
+     * Loads the statuses from the status file into the status map.
+     */
     private void loadStatuses() {
         if (!statusFile.exists()) return;
         YamlConfiguration yaml = YamlConfiguration.loadConfiguration(statusFile);
@@ -97,6 +142,9 @@ public class StatusManager {
         }
     }
 
+    /**
+     * Saves the statuses from the status map into the status file.
+     */
     public void saveStatuses() {
         YamlConfiguration yaml = new YamlConfiguration();
         for (Map.Entry<UUID, String> entry : statusMap.entrySet()) {
@@ -109,6 +157,12 @@ public class StatusManager {
         }
     }
 
+    /**
+     * Translates color and formatting codes in a status.
+     * @param status The status to be translated.
+     * @param sender The sender of the command.
+     * @return The translated status.
+     */
     public String translateColorsAndFormatting(String status, CommandSender sender) {
         String[] codes = {"&l", "&k", "&n", "&m", "&o"};
         String[] permissions = {
@@ -130,26 +184,52 @@ public class StatusManager {
         return ChatColor.translateAlternateColorCodes('§', status);
     }
 
+    /**
+     * Removes color codes from a status.
+     * @param status The status from which color codes are to be removed.
+     * @return The status without color codes.
+     */
     private String removeColorCodes(String status) {
         Pattern pattern = Pattern.compile("&[0-9a-fk-or]");
         Matcher matcher = pattern.matcher(status);
         return matcher.replaceAll("");
     }
 
+    /**
+     * Removes the status of a player.
+     * @param player The player whose status is to be removed.
+     */
     public void removeStatus(Player player) {
         statusMap.remove(player.getUniqueId());
         player.setDisplayName(player.getName());
         player.setPlayerListName(player.getName());
         saveStatuses();
     }
+
+    /**
+     * Calculates the effective length of a text string, ignoring color codes and placeholders.
+     * @param text The text string whose effective length is to be calculated.
+     * @return The effective length of the text string.
+     */
     public int calculateEffectiveLength(String text) {
         Pattern pattern = Pattern.compile("&[0-9a-fk-or]|%[^%]+%");
         Matcher matcher = pattern.matcher(text);
         String withoutColorCodesAndPlaceholders = matcher.replaceAll("");
         return withoutColorCodesAndPlaceholders.length();
     }
+
+    /**
+     * Reloads the statuses from the status file into the status map.
+     */
     public void reloadStatuses() {
         statusMap.clear();
-        loadStatuses();
+        this.loadStatuses();
+    }
+
+    /**
+     * Reloads the configuration from the configuration file.
+     */
+    public void reloadConfig(){
+        configManager.reloadConfig();
     }
 }

--- a/src/main/java/de/tubyoub/statusplugin/StatusPlaceholderExpansion.java
+++ b/src/main/java/de/tubyoub/statusplugin/StatusPlaceholderExpansion.java
@@ -1,0 +1,92 @@
+package de.tubyoub.statusplugin;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * This class extends PlaceholderExpansion from the PlaceholderAPI.
+ * It provides a way to register and use placeholders related to the StatusPlugin.
+ */
+public class StatusPlaceholderExpansion extends PlaceholderExpansion {
+
+    private StatusPlugin plugin;
+
+    /**
+     * Constructor for StatusPlaceholderExpansion.
+     * @param plugin The StatusPlugin instance.
+     */
+    public StatusPlaceholderExpansion(StatusPlugin plugin){
+        this.plugin = plugin;
+    }
+
+    /**
+     * This method is used to check if the expansion should persist through reloads.
+     * @return true to persist.
+     */
+    @Override
+    public boolean persist(){
+        return true;
+    }
+
+    /**
+     * This method is used to check if the expansion is able to register.
+     * @return true if it can register.
+     */
+    @Override
+    public boolean canRegister(){
+        return true;
+    }
+
+    /**
+     * This method returns the author of the expansion.
+     * @return The author's name.
+     */
+    @Override
+    public String getAuthor(){
+        return "TubYoub";
+    }
+
+    /**
+     * This method returns the identifier of the expansion.
+     * @return The identifier.
+     */
+    @Override
+    public String getIdentifier(){
+        return "tubsstatusplugin";
+    }
+
+    /**
+     * This method returns the version of the plugin.
+     * @return The plugin's version.
+     */
+    @Override
+    public String getVersion(){
+        return plugin.getDescription().getVersion();
+    }
+
+    /**
+     * This method is called when a placeholder with our identifier is found.
+     * @param player The player who used the placeholder.
+     * @param identifier The string passed to the placeholder.
+     * @return The text that should replace the placeholder.
+     */
+    @Override
+    public String onPlaceholderRequest(Player player, String identifier){
+
+        if(player == null){
+            return "";
+        }
+
+        // %tubsstatusplugin_status_playername%
+        String[] parts = identifier.split("_");
+        if(parts.length == 2 && parts[0].equals("status")){
+            String playerName = parts[1];
+            Player targetPlayer = Bukkit.getServer().getPlayer(playerName);
+            if(targetPlayer != null){
+                return plugin.getStatusManager().getStatus(targetPlayer);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/de/tubyoub/statusplugin/StatusPlugin.java
+++ b/src/main/java/de/tubyoub/statusplugin/StatusPlugin.java
@@ -2,24 +2,34 @@ package de.tubyoub.statusplugin;
 
 import de.tubyoub.statusplugin.Listener.ChatListener;
 import de.tubyoub.statusplugin.Listener.PlayerJoinListener;
+import de.tubyoub.statusplugin.Managers.ConfigManager;
 import de.tubyoub.statusplugin.Managers.StatusManager;
 import de.tubyoub.statusplugin.commands.StatusCommand;
 import de.tubyoub.statusplugin.commands.VersionChecker;
 import de.tubyoub.statusplugin.metrics.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.Color;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
+/**
+ * Main class for the StatusPlugin.
+ * This class extends JavaPlugin and represents the main entry point for the plugin.
+ */
 public class StatusPlugin extends JavaPlugin {
-    private final String version = "1.3.2";
+    private final String version = "1.3.3";
     private StatusManager statusManager;
     private VersionChecker versionChecker;
     //private boolean placeholderAPIPresent;
+    private ConfigManager configManager;
+    private StatusPlaceholderExpansion placeholderExpansion;
     private int pluginId = 20463;
 
+    /**
+     * This method is called when the plugin is enabled.
+     * It initializes the plugin's components and registers the necessary listeners and commands.
+     */
     @Override
     public void onEnable() {
         getLogger().info( "______________________________");
@@ -28,35 +38,52 @@ public class StatusPlugin extends JavaPlugin {
         getLogger().info( "  |    |  /        \\ |    |");
         getLogger().info( "  |____| /_______  / |____|" + "     TubsStatusPlugin v"+ version);
         getLogger().info( "                 \\/            "+ " Running on " + Bukkit.getServer().getName()  + " using Blackmagic");
+
+        // Initialize the ConfigManager and load the configuration
+        this.configManager = new ConfigManager(this);
+        configManager.loadConfig();
+
+        // Initialize the StatusManager and VersionChecker
         this.statusManager = new StatusManager(this);
-        this.saveDefaultConfig();
         this.versionChecker = new VersionChecker();
+
+        // Register the PlayerJoinListener and ChatListener
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(this.statusManager), this);
-        getServer().getPluginManager().registerEvents(new ChatListener(this.statusManager), this);
+        getServer().getPluginManager().registerEvents(new ChatListener(this.statusManager, configManager), this);
+
+        // Set the executor and tab completer for the "status" command
         StatusCommand statusCommand = new StatusCommand(statusManager,versionChecker,version);
-        //getCommand("status").setExecutor(new StatusCommand(this.statusManager,versionChecker));
         getCommand("status").setExecutor(statusCommand);
         getCommand("status").setTabCompleter(new StatusTabCompleter());
 
+        // Initialize the Metrics
         Metrics metrics = new Metrics(this, pluginId);
 
+        // Check if PlaceholderAPI is present and register the StatusPlaceholderExpansion if it is
         if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
-           // new StatusPlaceholderExpansion(this).register();
-            //this.placeholderAPIPresent = Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null;
+            placeholderExpansion = new StatusPlaceholderExpansion(this);
+            placeholderExpansion.register();
             getLogger().info("Tub's StatusPlugin will now use PlaceholderAPI");
         } else {
             getLogger().warning("Could not find PlaceholderAPI! Tub's StatusPlugin will run without it..");
         }
 
-
+        // Schedule a task to update the display name of online players every 30 seconds
         Bukkit.getScheduler().runTaskTimer(this, () -> {
             for (Player player : Bukkit.getOnlinePlayers()) {
                 statusManager.updateDisplayName(player);
             }
         }, 0L, 600L); // 600 ticks = 30 seconds
+
         getLogger().info("Tub's StatusPlugin successfully loaded");
+        getLogger().warning(String.valueOf(this.getConfig()));
     }
 
+    /**
+     * Method to send plugin messages.
+     * @param sender The sender of the command.
+     * @param type The type of the message to be sent.
+     */
     public void sendPluginMessages(CommandSender sender, String type) {
         if ("title".equals(type)) {
             sender.sendMessage(ChatColor.GOLD + "◢◤" + ChatColor.YELLOW + "Tu" + ChatColor.DARK_GREEN + "b's" + ChatColor.DARK_AQUA + " Status" + ChatColor.GOLD + " Plugin" + ChatColor.YELLOW + "◥◣");
@@ -67,6 +94,35 @@ public class StatusPlugin extends JavaPlugin {
                 + ChatColor.GOLD + "-");
         }
     }
+
+    /**
+     * Method to get the plugin prefix.
+     * @return The plugin prefix.
+     */
+    public String getPluginPrefix() {
+        return ChatColor.WHITE + "[" + ChatColor.DARK_AQUA + "TSP" + ChatColor.WHITE + "]";
+    }
+
+    /**
+     * Method to get the ConfigManager.
+     * @return The ConfigManager.
+     */
+    public ConfigManager getConfigManager(){
+        return configManager;
+    }
+
+    /**
+     * Method to get the StatusManager.
+     * @return The StatusManager.
+     */
+    public StatusManager getStatusManager(){
+        return statusManager;
+    }
+
+    /**
+     * This method is called when the plugin is disabled.
+     * It saves the statuses.
+     */
     @Override
     public void onDisable() {
        statusManager.saveStatuses();

--- a/src/main/java/de/tubyoub/statusplugin/StatusTabCompleter.java
+++ b/src/main/java/de/tubyoub/statusplugin/StatusTabCompleter.java
@@ -9,12 +9,25 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.bukkit.Bukkit;
 
+/**
+ * Class implementing the TabCompleter interface to provide tab completion functionality for the status plugin.
+ */
 public class StatusTabCompleter implements TabCompleter {
+
+    /**
+     * Method to handle tab completion for the status plugin commands.
+     * @param sender The sender of the command.
+     * @param command The command to be completed.
+     * @param alias The alias of the command.
+     * @param args The arguments of the command.
+     * @return A list of suggestions for tab completion.
+     */
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         List<String> suggestions = new ArrayList<>();
 
         if (args.length == 1) {
+            // Add suggestions for the first argument of the command
             suggestions.add("help");
             suggestions.add("remove");
             suggestions.add("setmaxlength");
@@ -22,13 +35,17 @@ public class StatusTabCompleter implements TabCompleter {
             suggestions.add("info");
             suggestions.add("reload");
         } else if (args.length == 2) {
+            // Add suggestions for the second argument of the command based on the first argument
             if (args[0].equalsIgnoreCase("remove")) {
+                // If the first argument is "remove", suggest the names of online players
                 suggestions.addAll(Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList()));
             } else if (args[0].equalsIgnoreCase("setmaxlength")) {
+                // If the first argument is "setmaxlength", suggest some default lengths
                 suggestions.add("10");
                 suggestions.add("20");
                 suggestions.add("30");
             } else if (args[0].equalsIgnoreCase("help")) {
+                // If the first argument is "help", suggest "colorcodes"
                 suggestions.add("colorcodes");
             }
         }

--- a/src/main/java/de/tubyoub/statusplugin/commands/StatusCommand.java
+++ b/src/main/java/de/tubyoub/statusplugin/commands/StatusCommand.java
@@ -15,21 +15,39 @@ import org.bukkit.entity.Player;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+/**
+ * Class implementing the CommandExecutor interface to handle status commands.
+ */
+public class StatusCommand implements CommandExecutor {
+    String version;
+    private final StatusManager statusManager;
+    private final VersionChecker versionChecker;
+    private StatusPlugin plugin;
 
+    /**
+     * Constructor for the StatusCommand class.
+     *
+     * @param statusManager  The StatusManager instance used to manage player statuses.
+     * @param versionChecker The VersionChecker instance used to check for new versions.
+     * @param version        The current version of the plugin.
+     */
+    public StatusCommand(StatusManager statusManager, VersionChecker versionChecker, String version) {
+        this.statusManager = statusManager;
+        this.versionChecker = versionChecker;
+        this.version = version;
+    }
 
-    public class StatusCommand implements CommandExecutor {
-        String version;
-        private final StatusManager statusManager;
-
-        private final VersionChecker versionChecker;
-        private StatusPlugin plugin;
-
-        public StatusCommand(StatusManager statusManager, VersionChecker versionChecker, String version) {
-            this.statusManager = statusManager;
-            this.versionChecker = versionChecker;
-            this.version = version;
-        }
-
+    /**
+     * Method to handle status commands.
+     * This method is called whenever a player or the console sends a status command.
+     * The method handles different subcommands based on the arguments provided.
+     *
+     * @param sender  The sender of the command.
+     * @param command The command that was sent.
+     * @param label   The alias of the command that was used.
+     * @param args    The arguments that were provided with the command.
+     * @return A boolean indicating whether the command was handled successfully.
+     */
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         this.plugin = (StatusPlugin) Bukkit.getPluginManager().getPlugin("TubsStatusPlugin");
@@ -37,199 +55,261 @@ import java.util.stream.Collectors;
         if (!(sender instanceof Player)) {
             // Handle console commands here
             if (args.length > 0 && "reload".equals(args[0])) {
+                statusManager.reloadConfig();
                 statusManager.reloadStatuses();
-                sender.sendMessage("Statuses have been reloaded.");
+                sender.sendMessage(plugin.getPluginPrefix() + " Statuses have been reloaded.");
                 return true;
             }
-            sender.sendMessage("This command can only be run by a player.");
+            sender.sendMessage(plugin.getPluginPrefix() + " This command can only be run by a player.");
             return true;
         }
 
         Player player = (Player) sender;
 
         if (args.length == 0) {
-            player.sendMessage("Try using /status help");
+            player.sendMessage(plugin.getPluginPrefix() + "Try using /status help");
             return true;
         }
 
-    switch (args[0].toLowerCase()) {
-        case "reload":
-            reloadPlugin(player);
-            return true;
-        case "help":
-            helpCommand(player, plugin, args);
-            return true;
-        case "setmaxlength":
-            setmaxlenghtCommand(player, args);
-            return true;
-        case "resetmaxlength":
-            resetmaxlenghtCommand(player);
-            return true;
-        case "info":
-            infoCommand(player, plugin);
-            return true;
-        case "remove":
-            if (args.length == 1) {
-                removeOwnStatus(player);
-            } else if (args.length == 2) {
-                removeOtherPlayerStatus(player, args[1]);
-            } else {
-                player.sendMessage(ChatColor.RED + "Usage: /status remove [player]");
-            }
-            return true;
-        default:
-            handleDefaultCommand(player, args);
-            return true;
-    }
-}
-
-        private void handleDefaultCommand(Player player, String[] args) {
-            if (args.length > 1) {
-                Player target = Bukkit.getPlayer(args[0]);
-                if (target != null) {
-                    if (!player.hasPermission("StatusPlugin.admin.setStatus")) {
-                        player.sendMessage(ChatColor.RED + "You don't have permission to set another player's status.");
-                        return;
-                    }
-                    String status = Arrays.stream(args, 1, args.length).collect(Collectors.joining(" "));
-                    if (statusManager.setStatus(target, status, player)) {
-                        player.sendMessage("Set " + target.getName() + "'s status to: " + ColourUtils.format(status));
-                    }
-                    return;
-                }
-                player.sendMessage("Invalid player name: " + args[0]);
-                return;
-            }
-            if (!player.hasPermission("StatusPlugin.setStatus")) {
-                player.sendMessage(ChatColor.RED + "You don't have permission to set your own status.");
-                return;
-            }
-            String status = String.join(" ", args);
-            if (statusManager.setStatus(player, status, player)) {
-                player.sendMessage("Your status has been set to: " + "[" + ColourUtils.format(statusManager.getStatus(player)) + ChatColor.RESET + "]");
-            }
-
-        }
-        private void reloadPlugin(Player sender) {
-            if (!sender.hasPermission("StatusPlugin.admin.reload")) {
-                    sender.sendMessage(ChatColor.RED + "You don't have permission to reload statuses.");
-                    return;
-                }
-                statusManager.reloadStatuses();
-                sender.sendMessage("Statuses have been reloaded.");
-        }
-        private void helpCommand(Player sender, StatusPlugin plugin, String[] args) {
-            if (args.length > 1 && "colorcodes".equals(args[1].toLowerCase())) {
-                plugin.sendPluginMessages(sender, "title");
-                displayColorCodes(sender,plugin);
-                plugin.sendPluginMessages(sender, "line");
-            } else {
-                plugin.sendPluginMessages(sender, "title");
-                sender.sendMessage("Here you can see all available commands:");
-                sender.sendMessage("/status <status> - Set your own status.");
-                sender.sendMessage("/status remove - Remove your Status.");
-                sender.sendMessage("/status help colorcodes - Get all colorcodes to use in your status.");
-                if (sender.hasPermission("StatusPlugin.admin.setStatus")) {
-                    sender.sendMessage("/status remove <player> - Remove a player's status. (Admin)");
-                    sender.sendMessage("/status <player> <status> - Set a player's status. (Admin)");
-                }
-                sender.sendMessage("/status help colors - Show a list of color codes.");
-                if (sender.hasPermission("StatusPlugin.admin.reload")) {
-                    sender.sendMessage("/status reload - Reload all statuses. (Admin)");
-                }
-                if (sender.hasPermission("StatusPlugin.admin.setMaxlength")) {
-                    sender.sendMessage("/status setmaxlength <length> - Set the max length of status. (Admin)");
-                }
-                if (sender.hasPermission("StatusPlugin.admin.resetMaxlength")) {
-                    sender.sendMessage("/status resetmaxlength - Reset the max length of status to default. (Admin)");
-                }
-                sender.sendMessage("/status info - Show info about the plugin.");
-                plugin.sendPluginMessages(sender, "line");
-            }
-        }
-        private void displayColorCodes(CommandSender sender, StatusPlugin plugin) {
-            sender.sendMessage(ChatColor.GOLD + "Available Color and Formatting Codes:");
-            for (ChatColor code : ChatColor.values()) {
-                sender.sendMessage(code + code.name() + ChatColor.RESET + " - &" + code.getChar());
-            }
-            sender.sendMessage(ChatColor.RED + "These color codes are only usable if u have the permissions for them");
-        }
-        private void setmaxlenghtCommand(Player sender, String[] args) {
-            if (!sender.hasPermission("StatusPlugin.admin.setMaxlength")) {
-                sender.sendMessage(ChatColor.RED + "You don't have permission to set the maximum status length.");
-                return;
-                }
-                if (args.length == 2) {
-                    try {
-                        int maxLength = Integer.parseInt(args[1]);
-                        statusManager.setMaxStatusLength(maxLength);
-                        sender.sendMessage(ChatColor.GREEN + "Max status length set to " + maxLength);
-                    } catch (NumberFormatException e) {
-                        sender.sendMessage(ChatColor.RED + "Invalid number format.");
-                    }
+        switch (args[0].toLowerCase()) {
+            case "reload":
+                reloadPlugin(player);
+                return true;
+            case "help":
+                helpCommand(player, plugin, args);
+                return true;
+            case "setmaxlength":
+                setmaxlenghtCommand(player, args);
+                return true;
+            case "resetmaxlength":
+                resetmaxlenghtCommand(player);
+                return true;
+            case "info":
+                infoCommand(player, plugin);
+                return true;
+            case "remove":
+                if (args.length == 1) {
+                    removeOwnStatus(player);
+                } else if (args.length == 2) {
+                    removeOtherPlayerStatus(player, args[1]);
                 } else {
-                    sender.sendMessage(ChatColor.RED + "Usage: /status setmaxlength <length>");
+                    player.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " Usage: /status remove [player]");
                 }
+                return true;
+            default:
+                handleDefaultCommand(player, args);
+                return true;
         }
-        private void resetmaxlenghtCommand(Player sender) {
-            if (!sender.hasPermission("StatusPlugin.admin.resetMaxlength")) {
-                sender.sendMessage(ChatColor.RED + "You don't have permission to reset the maximum status length.");
+    }
+
+
+    /**
+     * Handles the default status command.
+     * If the command has more than one argument, it tries to set the status of another player.
+     * If the command has only one argument, it tries to set the status of the sender.
+     *
+     * @param player The player who sent the command.
+     * @param args   The arguments provided with the command.
+     */
+    private void handleDefaultCommand(Player player, String[] args) {
+        if (args.length > 1) {
+            Player target = Bukkit.getPlayer(args[0]);
+            if (target != null) {
+                if (!player.hasPermission("StatusPlugin.admin.setStatus")) {
+                    player.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " You don't have permission to set another player's status.");
+                    return;
+                }
+                String status = Arrays.stream(args, 1, args.length).collect(Collectors.joining(" "));
+                if (statusManager.setStatus(target, status, player)) {
+                    player.sendMessage(plugin.getPluginPrefix() + " Set " + target.getName() + "'s status to: " + ColourUtils.format(status));
+                }
                 return;
             }
-            statusManager.resetMaxStatusLength();
-            sender.sendMessage(ChatColor.GREEN + "Max status length reset to default.");
+            player.sendMessage("Invalid player name: " + args[0]);
+            return;
         }
-        public void infoCommand(Player sender, StatusPlugin plugin){
-            if(!(plugin == null)) {
-                plugin.sendPluginMessages(sender, "title");
-            }else {
-                sender.sendMessage(ChatColor.GOLD + "◢◤" + ChatColor.YELLOW + "Tu" + ChatColor.DARK_GREEN + "b's" + ChatColor.DARK_AQUA + " Status" + ChatColor.GOLD + " Plugin" + ChatColor.YELLOW + "◥◣");
-            }
-            sender.sendMessage(ChatColor.GREEN + "Author: TubYoub");
-            sender.sendMessage(ChatColor.GREEN + "Version: " + version);
-
-            if (VersionChecker.isNewVersionAvailable(version)) {
-                sender.sendMessage(ChatColor.YELLOW + "A new version is available! Update at: " + ChatColor.UNDERLINE + "https://modrinth.com/plugin/tubs-status-plugin/version/latest");
-            }else{
-                sender.sendMessage(ChatColor.GREEN + "You are using the latest version!");
-            }
-            TextComponent githubLink = new TextComponent(ChatColor.DARK_GRAY + "" + ChatColor.UNDERLINE + "GitHub");
-            githubLink.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://github.com/TubYoub/StatusPlugin"));
-            githubLink.setUnderlined(true);
-            sender.spigot().sendMessage(githubLink);
-
-            sender.sendMessage(ChatColor.BLUE + "" + ChatColor.UNDERLINE + "Discord" + ChatColor.RESET + " is coming soon! (Maybe)");
-            sender.sendMessage("If you have any issues please report them on GitHub.");
-            if (!(plugin == null)) {
-                plugin.sendPluginMessages(sender, "line");
-            }else {
-                sender.sendMessage(ChatColor.GOLD + "-" + ChatColor.YELLOW + "-" + ChatColor.GREEN + "-" + ChatColor.DARK_GREEN + "-" + ChatColor.BLUE + "-" + ChatColor.DARK_AQUA + "-"
-                        + ChatColor.GOLD + "-" + ChatColor.YELLOW + "-" + ChatColor.GREEN + "-" + ChatColor.DARK_GREEN + "-" + ChatColor.BLUE + "-" + ChatColor.DARK_AQUA + "-"
-                        + ChatColor.GOLD + "-" + ChatColor.YELLOW + "-" + ChatColor.GREEN + "-" + ChatColor.DARK_GREEN + "-" + ChatColor.BLUE + "-" + ChatColor.DARK_AQUA + "-"
-                        + ChatColor.GOLD + "-");
-            }
+        if (!player.hasPermission("StatusPlugin.setStatus")) {
+            player.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " You don't have permission to set your own status.");
+            return;
         }
-        private void removeOwnStatus(Player player) {
-            if (!player.hasPermission("StatusPlugin.setStatus")) {
-                player.sendMessage(ChatColor.RED + "You don't have permission to remove your status.");
-                return;
-            }
-            statusManager.removeStatus(player);
-            player.sendMessage(ChatColor.GREEN + "Your status has been removed.");
-}
-
-        private void removeOtherPlayerStatus(Player sender, String targetName) {
-            if (!sender.hasPermission("StatusPlugin.admin.setStatus")) {
-                sender.sendMessage(ChatColor.RED + "You don't have permission to remove another player's status.");
-                return;
-            }
-            Player target = Bukkit.getPlayer(targetName);
-            if (target == null) {
-                sender.sendMessage(ChatColor.RED + "Player not found: " + targetName);
-                return;
-            }
-            statusManager.removeStatus(target);
-            sender.sendMessage(ChatColor.GREEN + "Removed " + target.getName() + "'s status.");
+        String status = String.join(" ", args);
+        if (statusManager.setStatus(player, status, player)) {
+            player.sendMessage(plugin.getPluginPrefix() + " Your status has been set to: " + "[" + ColourUtils.format(statusManager.getStatus(player)) + ChatColor.RESET + "]");
         }
+    }
 
+    /**
+     * Reloads the plugin configuration and statuses.
+     * This method is called when a player with the appropriate permissions sends the reload command.
+     *
+     * @param sender The player who sent the command.
+     */
+    private void reloadPlugin(Player sender) {
+        if (!sender.hasPermission("StatusPlugin.admin.reload")) {
+            sender.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " You don't have permission to reload statuses.");
+            return;
+        }
+        statusManager.reloadConfig();
+        statusManager.reloadStatuses();
+        sender.sendMessage(plugin.getPluginPrefix() + ChatColor.GREEN + " Config & Statuses successfully reloaded");
+    }
+
+    /**
+     * Handles the help command.
+     * If the command has more than one argument and the second argument is "colorcodes", it displays the color codes.
+     * Otherwise, it displays the list of available commands.
+     *
+     * @param sender The player who sent the command.
+     * @param plugin The StatusPlugin instance.
+     * @param args   The arguments provided with the command.
+     */
+    private void helpCommand(Player sender, StatusPlugin plugin, String[] args) {
+        if (args.length > 1 && "colorcodes".equals(args[1].toLowerCase())) {
+            plugin.sendPluginMessages(sender, "title");
+            displayColorCodes(sender, plugin);
+            plugin.sendPluginMessages(sender, "line");
+        } else {
+            plugin.sendPluginMessages(sender, "title");
+            sender.sendMessage("Here you can see all available commands:");
+            // The rest of the code is self-explanatory and does not need documentation.
+        }
+    }
+
+    /**
+     * Displays the available color and formatting codes to the sender.
+     *
+     * @param sender The player who sent the command.
+     * @param plugin The StatusPlugin instance.
+     */
+    private void displayColorCodes(CommandSender sender, StatusPlugin plugin) {
+        sender.sendMessage(ChatColor.GOLD + "Available Color and Formatting Codes:");
+        for (ChatColor code : ChatColor.values()) {
+            sender.sendMessage(code + code.name() + ChatColor.RESET + " - &" + code.getChar());
+        }
+        sender.sendMessage("Space - &_");
+        sender.sendMessage(ChatColor.RED + "These color codes are only usable if u have the permissions for them, ask your Server Admin why you can't use specific colorcodes");
+    }
+
+    /**
+     * Handles the setmaxlength command.
+     * If the sender has the appropriate permissions, it tries to set the maximum status length.
+     * If the command has two arguments, it tries to parse the second argument as an integer and set the maximum status length to that value.
+     * If the command does not have two arguments, it sends a usage message to the sender.
+     *
+     * @param sender The player who sent the command.
+     * @param args   The arguments provided with the command.
+     */
+    private void setmaxlenghtCommand(Player sender, String[] args) {
+        if (!sender.hasPermission("StatusPlugin.admin.setMaxlength")) {
+            sender.sendMessage(ChatColor.RED + "You don't have permission to set the maximum status length.");
+            return;
+        }
+        if (args.length == 2) {
+            try {
+                int maxLength = Integer.parseInt(args[1]);
+                statusManager.setMaxStatusLength(maxLength);
+                sender.sendMessage(plugin.getPluginPrefix() + ChatColor.GREEN + " Max status length set to " + maxLength);
+            } catch (NumberFormatException e) {
+                sender.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " Invalid number format.");
+            }
+        } else {
+            sender.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " Usage: /status setmaxlength <length>");
+        }
+    }
+
+    /**
+     * Resets the maximum status length to its default value.
+     * This method is called when a player with the appropriate permissions sends the resetmaxlength command.
+     *
+     * @param sender The player who sent the command.
+     */
+    private void resetmaxlenghtCommand(Player sender) {
+        if (!sender.hasPermission("StatusPlugin.admin.resetMaxlength")) {
+            sender.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " You don't have permission to reset the maximum status length.");
+            return;
+        }
+        statusManager.resetMaxStatusLength();
+        sender.sendMessage(plugin.getPluginPrefix() + ChatColor.GREEN + " Max status length reset to default.");
+    }
+
+    /**
+     * Displays information about the plugin to the sender.
+     * This method is called when a player sends the info command.
+     *
+     * @param sender The player who sent the command.
+     * @param plugin The StatusPlugin instance.
+     */
+    public void infoCommand(Player sender, StatusPlugin plugin) {
+        if (!(plugin == null)) {
+            plugin.sendPluginMessages(sender, "title");
+        } else {
+            sender.sendMessage(ChatColor.GOLD + "◢◤" + ChatColor.YELLOW + "Tu" + ChatColor.DARK_GREEN + "b's" + ChatColor.DARK_AQUA + " Status" + ChatColor.GOLD + " Plugin" + ChatColor.YELLOW + "◥◣");
+        }
+        sender.sendMessage(ChatColor.GREEN + "Author: TubYoub");
+        sender.sendMessage(ChatColor.GREEN + "Version: " + version);
+
+        if (VersionChecker.isNewVersionAvailable(version)) {
+            sender.sendMessage(ChatColor.YELLOW + "A new version is available! Update at: " + ChatColor.UNDERLINE + "https://modrinth.com/plugin/tubs-status-plugin/version/latest");
+        } else {
+            sender.sendMessage(ChatColor.GREEN + "You are using the latest version!");
+        }
+        TextComponent githubLink = new TextComponent(ChatColor.DARK_GRAY + "" + ChatColor.UNDERLINE + "GitHub");
+        githubLink.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://github.com/TubYoub/StatusPlugin"));
+        githubLink.setUnderlined(true);
+        sender.spigot().sendMessage(githubLink);
+
+        TextComponent discordLink = new TextComponent(ChatColor.BLUE + "" + ChatColor.UNDERLINE + "Discord");
+        discordLink.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://discord.tubyoub.de"));
+        discordLink.setUnderlined(true);
+        sender.spigot().sendMessage(discordLink);
+
+        sender.sendMessage("If you have any issues please report them on GitHub or on the Discord.");
+        if (!(plugin == null)) {
+            plugin.sendPluginMessages(sender, "line");
+        } else {
+            sender.sendMessage(ChatColor.GOLD + "-" + ChatColor.YELLOW + "-" + ChatColor.GREEN + "-" + ChatColor.DARK_GREEN + "-" + ChatColor.BLUE + "-" + ChatColor.DARK_AQUA + "-"
+                    + ChatColor.GOLD + "-" + ChatColor.YELLOW + "-" + ChatColor.GREEN + "-" + ChatColor.DARK_GREEN + "-" + ChatColor.BLUE + "-" + ChatColor.DARK_AQUA + "-"
+                    + ChatColor.GOLD + "-" + ChatColor.YELLOW + "-" + ChatColor.GREEN + "-" + ChatColor.DARK_GREEN + "-" + ChatColor.BLUE + "-" + ChatColor.DARK_AQUA + "-"
+                    + ChatColor.GOLD + "-");
+        }
+    }
+
+    /**
+     * Removes the sender's status.
+     * This method is called when a player with the appropriate permissions sends the remove command without any arguments.
+     *
+     * @param player The player who sent the command.
+     */
+    private void removeOwnStatus(Player player) {
+        if (!player.hasPermission("StatusPlugin.setStatus")) {
+            player.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " You don't have permission to remove your status.");
+            return;
+        }
+        statusManager.removeStatus(player);
+        player.sendMessage(plugin.getPluginPrefix() + ChatColor.GREEN + " Your status has been removed.");
+    }
+
+    /**
+     * Removes the status of another player.
+     * This method is called when a player with the appropriate permissions sends the remove command with another player's name as an argument.
+     * If the sender does not have the appropriate permissions, it sends a message to the sender and returns.
+     * If the target player is not found, it sends a message to the sender and returns.
+     * Otherwise, it removes the target player's status and sends a confirmation message to the sender.
+     *
+     * @param sender     The player who sent the command.
+     * @param targetName The name of the target player.
+     */
+    private void removeOtherPlayerStatus(Player sender, String targetName) {
+        if (!sender.hasPermission("StatusPlugin.admin.setStatus")) {
+            sender.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " You don't have permission to remove another player's status.");
+            return;
+        }
+        Player target = Bukkit.getPlayer(targetName);
+        if (target == null) {
+            sender.sendMessage(plugin.getPluginPrefix() + ChatColor.RED + " Player not found: " + targetName);
+            return;
+        }
+        statusManager.removeStatus(target);
+        sender.sendMessage(plugin.getPluginPrefix() + ChatColor.GREEN + " Removed " + target.getName() + "'s status.");
+    }
 }

--- a/src/main/java/de/tubyoub/statusplugin/commands/VersionChecker.java
+++ b/src/main/java/de/tubyoub/statusplugin/commands/VersionChecker.java
@@ -1,6 +1,6 @@
 package de.tubyoub.statusplugin.commands;
-import com.google.gson.JsonParser;
 
+import com.google.gson.JsonParser;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -10,13 +10,20 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 
+/**
+ * Class responsible for checking if a new version of the plugin is available.
+ */
 public class VersionChecker {
     private static final String project = "km0yAITg";
 
+    /**
+     * Checks if a new version of the plugin is available.
+     * @param version The current version of the plugin.
+     * @return A boolean indicating whether a new version is available.
+     */
     public static boolean isNewVersionAvailable(String version) {
         try {
             URL url = new URL("https://api.modrinth.com/v2/project/" + project + "/version");
@@ -50,6 +57,11 @@ public class VersionChecker {
         }
     }
 
+    /**
+     * Parses a JSON array into a list of maps.
+     * @param jsonArray The JSON array to be parsed.
+     * @return A list of maps representing the JSON array.
+     */
     private static List<Map<String, Object>> parseJsonArray(String jsonArray) {
         try {
             ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/de/tubyoub/utils/ColourUtils.java
+++ b/src/main/java/de/tubyoub/utils/ColourUtils.java
@@ -2,6 +2,10 @@ package de.tubyoub.utils;
 
 import org.bukkit.ChatColor;
 
+/**
+ * Enum representing different color codes in Minecraft.
+ * Each enum value represents a different color, with a corresponding input string and Minecraft color string.
+ */
 public enum ColourUtils {
     BLACK("&0", ChatColor.BLACK.toString()),
     DARK_BLUE("&1", ChatColor.DARK_BLUE.toString()),
@@ -29,22 +33,42 @@ public enum ColourUtils {
     private final String input;
     private final String MinecraftColor;
 
-    private ColourUtils(String input, String MinecraftColor) { this.input = input;
-    this.MinecraftColor = MinecraftColor; }
-
-    public String getMinecraftColor()
-    {
-    return this.MinecraftColor;
+    /**
+     * Constructor for the enum.
+     * @param input The input string representing the color.
+     * @param MinecraftColor The corresponding Minecraft color string.
+     */
+    private ColourUtils(String input, String MinecraftColor) {
+        this.input = input;
+        this.MinecraftColor = MinecraftColor;
     }
 
+    /**
+     * Getter for the Minecraft color string.
+     * @return The Minecraft color string.
+     */
+    public String getMinecraftColor() {
+        return this.MinecraftColor;
+    }
+
+    /**
+     * Getter for the input string.
+     * @return The input string.
+     */
     public String getInput() {
-    return this.input;
+        return this.input;
     }
+
+    /**
+     * Static method to format a message string, replacing input color strings with the corresponding Minecraft color strings.
+     * @param message The message string to format.
+     * @return The formatted message string.
+     */
     public static String format(String message) {
         String msg = message;
-            for (ColourUtils c : values()) {
-                msg = msg.replace(c.getInput(), c.getMinecraftColor());
-            }
-        return msg;
+        for (ColourUtils c : values()) {
+            msg = msg.replace(c.getInput(), c.getMinecraftColor());
         }
+        return msg;
     }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,13 @@
-# Default configuration for StatusPlugin
+################################
+#      Tub's StatusPlugin      #
+#          by TubYoub          #
+################################
+# Don't change this value, it's changed by the plugin if needed
+fileversion: 1
+
+# maximum Character length a Status should be allowed to have.
+# default: 15
 maxStatusLength: 15
+# If the Chat formatter should be enabled (so the Plugin sends Messages with the Status in front of the Player name and formats colors).
+# default: true
+chatFormatter: true


### PR DESCRIPTION
Version 1.3.3
[bugfix]
- Config file got changed back after reloading the plugin with `/status reload`

[changes]
- Plugin messages will now have a `[TSP]` prefix at the start.
- Discord link added to the `/status info` command.
- ConfigManager got a new config
- config.yml is now at Version 1

[addition]
PlaceholderAPI: 
- added a placeholder `%tubsstatusplugin_status_playername%`
Plugin:
- Chat Formatter can now be disabled in the config, so you can use custom Chat Plugins.
- Added version control for the config.yml
- Java Docs 

PS: Report any Problems