### PR TITLE
Version 1.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,18 @@
 ![Static Badge](https://img.shields.io/badge/MC-1.18-green)
 ![Static Badge](https://img.shields.io/badge/MC-1.19-green)
 ![Static Badge](https://img.shields.io/badge/MC-1.20-green)
+![Modrinth Downloads](https://img.shields.io/modrinth/dt/km0yAITg?logo=Modrinth&style=flat-square)
 
-[![forthebadge](https://forthebadge.com/images/badges/works-on-my-machine.svg)](https://forthebadge.com)
+
+![forthebadge](https://forthebadge.com/images/badges/works-on-my-machine.svg)
+
+<p align="center">
+    <a href="https://discord.tubyoub.de">
+        <img src="https://i.imgur.com/JgDt1Fl.png" width="300">
+    </a>
+    <br/>
+    <i>Please join the Discord if you have questions!</i>
+</p>
 
 
 This is a Minecraft plugin for Spigot/Paper servers that allows players to set their own status, which is displayed in the tab list and above their heads in-game.
@@ -28,7 +38,9 @@ This is a Minecraft plugin for Spigot/Paper servers that allows players to set t
 - The status of every player is saved to a file, so they will keep their status when they rejoin the server.
 - The Plugin supports `PlaceholderAPI v2.11.5`
   - The Plugin reloads statuses every 600 Game Ticks (30seconds) so the Placeholders can update themselves.
-  - The Plugin now got a Placeholder`%tubsstatusplugin_status_playername%` (playname should be changed out for the real Playername, Duuuh.)
+  - The Plugin got Placeholders:
+    - `%tubsstatusplugin_status_playername%` (playname should be changed out for the real Playername, Duuuh.)
+    - `%tubsstatusplugin_status%`
 
 ## Permissions
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.tubyoub</groupId>
     <artifactId>StatusPlugin</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <packaging>jar</packaging>
 
     <name>Tub's Status Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.tubyoub</groupId>
     <artifactId>StatusPlugin</artifactId>
-    <version>1.3.4</version>
+    <version>1.3.5</version>
     <packaging>jar</packaging>
 
     <name>Tub's Status Plugin</name>

--- a/src/main/java/de/tubyoub/statusplugin/Listener/PlayerJoinListener.java
+++ b/src/main/java/de/tubyoub/statusplugin/Listener/PlayerJoinListener.java
@@ -1,6 +1,7 @@
 package de.tubyoub.statusplugin.Listener;
 
 import de.tubyoub.statusplugin.Managers.StatusManager;
+import de.tubyoub.statusplugin.StatusPlugin;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -12,13 +13,14 @@ import org.bukkit.event.player.PlayerJoinEvent;
  */
 public class PlayerJoinListener implements Listener {
     private final StatusManager statusManager;
-
+    private final StatusPlugin plugin;
     /**
      * Constructor for the PlayerJoinListener class.
      * @param statusManager The StatusManager instance used to manage player statuses.
      */
-    public PlayerJoinListener(StatusManager statusManager) {
+    public PlayerJoinListener(StatusPlugin plugin, StatusManager statusManager) {
         this.statusManager = statusManager;
+        this.plugin = plugin;
     }
 
     /**
@@ -28,7 +30,9 @@ public class PlayerJoinListener implements Listener {
      */
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
-        statusManager.updateDisplayName(player);
+        if (plugin.getConfigManager().isTablistFormatter()) {
+            Player player = event.getPlayer();
+            statusManager.updateDisplayName(player);
+        }
     }
 }

--- a/src/main/java/de/tubyoub/statusplugin/Managers/ConfigManager.java
+++ b/src/main/java/de/tubyoub/statusplugin/Managers/ConfigManager.java
@@ -16,7 +16,7 @@ public class ConfigManager {
     private YamlDocument config;
     private int maxStatusLength;
     private boolean chatFormatter;
-    private boolean changeTabListNames;
+    private boolean tablistFormatter;
     private final StatusPlugin plugin;
 
     public ConfigManager(StatusPlugin plugin) {
@@ -36,6 +36,7 @@ public class ConfigManager {
 
             maxStatusLength = config.getInt("maxStatusLength", 15);
             chatFormatter = config.getBoolean("chatFormatter", true);
+            tablistFormatter = config.getBoolean("changeTablistNames", true);
         } catch (IOException e) {
             plugin.getLogger().severe("Could not load configuration: " + e.getMessage());
         }
@@ -48,7 +49,17 @@ public class ConfigManager {
             plugin.getLogger().severe("Could not save configuration: " + e.getMessage());
         }
     }
-
+    public boolean isTablistFormatter(){
+        return tablistFormatter;
+    }
+    public void setTablistFormatter(boolean tablistFormatter){
+        if (this.tablistFormatter == tablistFormatter){
+            return;
+        }else {
+            this.tablistFormatter = tablistFormatter;
+            config.set("changeTablistNames", tablistFormatter);
+        }
+    }
     public boolean isChatFormatter(){
         return chatFormatter;
     }

--- a/src/main/java/de/tubyoub/statusplugin/Managers/StatusManager.java
+++ b/src/main/java/de/tubyoub/statusplugin/Managers/StatusManager.java
@@ -65,7 +65,9 @@ public class StatusManager {
 
         // Store the original status, not the translated one
         statusMap.put(player.getUniqueId(), status);
-        updateDisplayName(player);
+        if (configManager.isTablistFormatter()) {
+            updateDisplayName(player);
+        }
         saveStatuses();
         return true;
     }
@@ -76,7 +78,10 @@ public class StatusManager {
      * @return The status of the player.
      */
     public String getStatus(Player player) {
-        return statusMap.get(player.getUniqueId());
+        if (statusMap.containsKey(player.getUniqueId())){
+            return statusMap.get(player.getUniqueId());
+        }
+        return "";
     }
 
 

--- a/src/main/java/de/tubyoub/statusplugin/StatusPlaceholderExpansion.java
+++ b/src/main/java/de/tubyoub/statusplugin/StatusPlaceholderExpansion.java
@@ -4,6 +4,8 @@ import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import java.util.Objects;
+
 /**
  * This class extends PlaceholderExpansion from the PlaceholderAPI.
  * It provides a way to register and use placeholders related to the StatusPlugin.
@@ -73,9 +75,11 @@ public class StatusPlaceholderExpansion extends PlaceholderExpansion {
      */
     @Override
     public String onPlaceholderRequest(Player player, String identifier){
-
         if(player == null){
             return "";
+        }
+        if (Objects.equals(identifier, "status")){
+            return plugin.getStatusManager().getStatus(player);
         }
 
         // %tubsstatusplugin_status_playername%

--- a/src/main/java/de/tubyoub/statusplugin/StatusPlugin.java
+++ b/src/main/java/de/tubyoub/statusplugin/StatusPlugin.java
@@ -18,7 +18,7 @@ import org.bukkit.plugin.java.JavaPlugin;
  * This class extends JavaPlugin and represents the main entry point for the plugin.
  */
 public class StatusPlugin extends JavaPlugin {
-    private final String version = "1.3.4";
+    private final String version = "1.3.5";
     private StatusManager statusManager;
     private VersionChecker versionChecker;
     //private boolean placeholderAPIPresent;

--- a/src/main/java/de/tubyoub/statusplugin/commands/StatusCommand.java
+++ b/src/main/java/de/tubyoub/statusplugin/commands/StatusCommand.java
@@ -3,6 +3,7 @@ package de.tubyoub.statusplugin.commands;
 import de.tubyoub.statusplugin.Managers.StatusManager;
 import de.tubyoub.statusplugin.StatusPlugin;
 import de.tubyoub.utils.ColourUtils;
+import de.tubyoub.utils.VersionChecker;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
@@ -21,19 +22,19 @@ import java.util.stream.Collectors;
 public class StatusCommand implements CommandExecutor {
     String version;
     private final StatusManager statusManager;
-    private final VersionChecker versionChecker;
+    private final boolean newVersion;
     private StatusPlugin plugin;
 
     /**
      * Constructor for the StatusCommand class.
      *
      * @param statusManager  The StatusManager instance used to manage player statuses.
-     * @param versionChecker The VersionChecker instance used to check for new versions.
+     * @param newVersion If the plugin has a new Version..
      * @param version        The current version of the plugin.
      */
-    public StatusCommand(StatusManager statusManager, VersionChecker versionChecker, String version) {
+    public StatusCommand(StatusManager statusManager, boolean newVersion, String version) {
         this.statusManager = statusManager;
-        this.versionChecker = versionChecker;
+        this.newVersion = newVersion;
         this.version = version;
     }
 
@@ -248,7 +249,7 @@ public class StatusCommand implements CommandExecutor {
         sender.sendMessage(ChatColor.GREEN + "Author: TubYoub");
         sender.sendMessage(ChatColor.GREEN + "Version: " + version);
 
-        if (VersionChecker.isNewVersionAvailable(version)) {
+        if (newVersion) {
             sender.sendMessage(ChatColor.YELLOW + "A new version is available! Update at: " + ChatColor.UNDERLINE + "https://modrinth.com/plugin/tubs-status-plugin/version/latest");
         } else {
             sender.sendMessage(ChatColor.GREEN + "You are using the latest version!");

--- a/src/main/java/de/tubyoub/statusplugin/commands/StatusCommand.java
+++ b/src/main/java/de/tubyoub/statusplugin/commands/StatusCommand.java
@@ -172,9 +172,29 @@ public class StatusCommand implements CommandExecutor {
         } else {
             plugin.sendPluginMessages(sender, "title");
             sender.sendMessage("Here you can see all available commands:");
-            // The rest of the code is self-explanatory and does not need documentation.
+            plugin.sendPluginMessages(sender, "title");
+                sender.sendMessage("Here you can see all available commands:");
+                sender.sendMessage("/status <status> - Set your own status.");
+                sender.sendMessage("/status remove - Remove your Status.");
+                sender.sendMessage("/status help colorcodes - Get all colorcodes to use in your status.");
+                if (sender.hasPermission("StatusPlugin.admin.setStatus")) {
+                    sender.sendMessage("/status remove <player> - Remove a player's status. (Admin)");
+                    sender.sendMessage("/status <player> <status> - Set a player's status. (Admin)");
+                }
+                sender.sendMessage("/status help colors - Show a list of color codes.");
+                if (sender.hasPermission("StatusPlugin.admin.reload")) {
+                    sender.sendMessage("/status reload - Reload all statuses. (Admin)");
+                }
+                if (sender.hasPermission("StatusPlugin.admin.setMaxlength")) {
+                    sender.sendMessage("/status setmaxlength <length> - Set the max length of status. (Admin)");
+                }
+                if (sender.hasPermission("StatusPlugin.admin.resetMaxlength")) {
+                    sender.sendMessage("/status resetmaxlength - Reset the max length of status to default. (Admin)");
+                }
+                sender.sendMessage("/status info - Show info about the plugin.");
+                plugin.sendPluginMessages(sender, "line");
+            }
         }
-    }
 
     /**
      * Displays the available color and formatting codes to the sender.

--- a/src/main/java/de/tubyoub/utils/VersionChecker.java
+++ b/src/main/java/de/tubyoub/utils/VersionChecker.java
@@ -1,6 +1,8 @@
-package de.tubyoub.statusplugin.commands;
+package de.tubyoub.utils;
 
-import com.google.gson.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -10,8 +12,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.core.type.TypeReference;
 
 /**
  * Class responsible for checking if a new version of the plugin is available.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,7 @@
 #          by TubYoub          #
 ################################
 # Don't change this value, it's changed by the plugin if needed
-fileversion: 1
+fileversion: 2
 
 # maximum Character length a Status should be allowed to have.
 # default: 15
@@ -11,3 +11,6 @@ maxStatusLength: 15
 # If the Chat formatter should be enabled (so the Plugin sends Messages with the Status in front of the Player name and formats colors).
 # default: true
 chatFormatter: true
+# If the Tablist name should be changed by the plugin or not. (restart your server so the changes will work correctly)
+# default: true
+changeTablistNames: true


### PR DESCRIPTION
Version 1.3.4
[bugfix]
/

[changes]
- The Plugin only checks for a new Version on start so the `/status info` command can instantly send and don't request every time when used if a new Version is available 
- if a Player doesn't have a Status `StatusManager.getStatus()` will give an empty `String` back.
- changed `config` version to `2`

[addition]
PlaceholderAPI: 
- added a placeholder `%tubsstatusplugin_status%`

Config:
- Tablist formatter can now be disabled
PS: Report any Problems